### PR TITLE
Add CNAME file pointing to naked xunit.net

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+xunit.net


### PR DESCRIPTION
Resolves https://github.com/xunit/xunit/issues/753.

In order for the domain to work with github pages, you need to do the following (worked for my blog):
# Code Changes
- Add a CNAME file with a reference to your naked domain (what this PR does).
# DNS Changes
- Add two A records for your `@`, to `192.30.252.153` and `192.30.252.153` (pages.github.com)
- Add a CNAME for your `www` record, pointing to `xunit.github.io.`

The combination of these two should get things working again.

See the [screenshot of my DNS settings](http://i.imgur.com/hWMYZLn.png), and [my CNAME file that I use](https://github.com/SeanKilleen/seankilleen.github.io/blob/master/CNAME).
