### PR TITLE
Omit protocol from embedded font resources

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% if page.title }%}{{page.title}} &gt; {% endif %}xUnit.net</title>
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro:400,600' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Open+Sans:400,400italic,600' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Source+Code+Pro:400,600' rel='stylesheet' type='text/css'>
   <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
   <link href="/css/pygments.css" rel="stylesheet">
   <link href="/css/site.css" rel="stylesheet">


### PR DESCRIPTION
Fixes the mixed content errors and loads fonts when accessing
https://xunit.github.io/