### PR TITLE
Updated platform names

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@ redirect_from: "/docs/running-tests-in-vs.html"
       <td>&check; <sup>3d</sup></td>
     </tr>
     <tr>
-      <th>DNX and ASP.NET 5<br />(Windows, Linux, OS X)</th>
+      <th>Dotnet CLI and .NET Core<br />(Windows, Linux, OS X)</th>
       <td>2.1 beta 2+</td>
       <td>&check; <sup>3e</sup></td>
       <td>&nbsp;</td>


### PR DESCRIPTION
- DNX is no more
- ASP.NET 5 -> ASP.NET Core
- Also this works for .NET Core without ASP.NET? So ASP.NET 5 -> .NET Core