### PR TITLE
Update shared-context.html

### DIFF
--- a/docs/shared-context.html
+++ b/docs/shared-context.html
@@ -359,7 +359,7 @@ public class DatabaseTestClass2
 </p>
 
 <p><em>
-  <strong>Important note:</strong> Fixtures <strong>must</strong> be in the
+  <strong>Important note:</strong> Fixtures can be shared across assemblies, but collection definitions <strong>must</strong> be in the
   same assembly as the test that uses them.
 </em></p>
 


### PR DESCRIPTION
According to https://github.com/xunit/xunit/issues/374#issuecomment-90281871, it is supported to have the fixture in a separate assembly from the unit test, as long as there is a collection definition in the same assembly as the test.