### PR TITLE
Fix 404 on links to beta release notes

### DIFF
--- a/releases/2.1.html
+++ b/releases/2.1.html
@@ -120,11 +120,11 @@ redirect_from: "/release-notes/2015-09-27.html"
 <p>The following individual releases contributed to 2.1:</p>
 
 <ul>
-  <li><a href="2015-03-21.html">March 21st (2.1 Beta 1)</a></li>
-  <li><a href="2015-05-03.html">May 3rd (2.1 Beta 2)</a></li>
-  <li><a href="2015-06-30.html">June 30th (2.1 Beta 3)</a></li>
-  <li><a href="2015-07-13.html">July 13th (VS Runner 2.0.1)</a></li>
-  <li><a href="2015-08-04.html">August 4th (2.1 Beta 4)</a></li>
-  <li><a href="2015-09-06.html">September 6th (2.1 RC 1)</a></li>
-  <li><a href="2015-09-20.html">September 20th (2.1 RC 2)</a></li>
+  <li><a href="2.1-beta1.html">March 21st (2.1 Beta 1)</a></li>
+  <li><a href="2.1-beta2.html">May 3rd (2.1 Beta 2)</a></li>
+  <li><a href="2.1-beta3.html">June 30th (2.1 Beta 3)</a></li>
+  <li><a href="2.0.1.html">July 13th (VS Runner 2.0.1)</a></li>
+  <li><a href="2.1-beta4.html">August 4th (2.1 Beta 4)</a></li>
+  <li><a href="2.1-rc1.html">September 6th (2.1 RC 1)</a></li>
+  <li><a href="2.1-rc2.html">September 20th (2.1 RC 2)</a></li>
 </ul>

--- a/releases/2.2.html
+++ b/releases/2.2.html
@@ -121,10 +121,10 @@ redirect_from: "/release-notes/2017-02-19.html"
 <p>The following individual releases contributed to 2.2:</p>
 
 <ul>
-  <li><a href="2016-11-06.html">November 6, 2016 (2.2 Beta 4)</a></li>
-  <li><a href="2016-10-05.html">October 5, 2016 (2.2 Beta 3)</a></li>
-  <li><a href="2016-06-27.html">June 27, 2016 (2.2 Beta 2)</a></li>
-  <li><a href="2015-12-20.html">December 20, 2015 (2.2 Beta 1)</a></li>
+  <li><a href="2.2-beta4.html">November 6, 2016 (2.2 Beta 4)</a></li>
+  <li><a href="2.2-beta3.html">October 5, 2016 (2.2 Beta 3)</a></li>
+  <li><a href="2.2-beta2.html">June 27, 2016 (2.2 Beta 2)</a></li>
+  <li><a href="2.2-beta1.html">December 20, 2015 (2.2 Beta 1)</a></li>
 </ul>
 
 <p>


### PR DESCRIPTION
Despite the /release-notes/* redirections these links were giving 404s as they were relative to the /releases/ folder.